### PR TITLE
Add CURLOPT_HTTP09_ALLOWED for libcurl >= 7.64.0

### DIFF
--- a/src/ntrip_ping.c
+++ b/src/ntrip_ping.c
@@ -167,6 +167,9 @@ int request(void)
   curl_easy_setopt(curl, CURLOPT_NOPROGRESS,       0L);
   curl_easy_setopt(curl, CURLOPT_PUT,              1L);
   curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST,    "GET");
+#if LIBCURL_VERSION_MAJOR > 7 || (LIBCURL_VERSION_MAJOR >= 7 && LIBCURL_VERSION_MINOR >= 64)
+  curl_easy_setopt(curl, CURLOPT_HTTP09_ALLOWED,   1L);
+#endif
 
   code = curl_easy_perform(curl);
   if (code != CURLE_OK) {


### PR DESCRIPTION
See https://curl.haxx.se/libcurl/c/CURLOPT_HTTP09_ALLOWED.html -- this must be set for libcurl >= 7.64.0 otherwise it rejects the "ICY 200 OK" response from the ntrip server.