### PR TITLE
Add option for verbose, debug and no ephemerides on connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,13 @@ The `ntripping` utility has the following usage:
     Usage: ntripping
 
     Main options
-            --url    <url>
-            --lat    <latitude>
-            --lon    <longitude>
-            --height <height>
-
+            --url     <url>
+            --lat     <latitude>
+            --lon     <longitude>
+            --height  <height>
+            --no-eph  Disable ephemerides on connection (X-No-Ephemerides-On-Connection)
+            --verbose Enable curl verbose output
+            --debug   Enable debug output
 Different resources can be requested from different locations. By default, a San
 Francisco latitude, longitude, and height will be used.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The `ntripping` utility has the following usage:
             --height  <height>
             --no-eph  Disable ephemerides on connection (X-No-Ephemerides-On-Connection)
             --verbose Enable curl verbose output
-            --debug   Enable debug output
+            --debug   Enable curl debug output
 Different resources can be requested from different locations. By default, a San
 Francisco latitude, longitude, and height will be used.
 

--- a/src/ntrip_ping.c
+++ b/src/ntrip_ping.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <time.h>
 #include <curl/curl.h>
+#include <stdbool.h>
 
 char *url = "conus.swiftnav.com:2101/VRS";
 char *lat = "37.77101999622968";
@@ -12,6 +13,9 @@ char *lon = "-122.40315159140708";
 char *height = "-5.549358852471994";
 char *epoch = "";
 char *client = "00000000-0000-0000-0000-000000000000";
+bool no_eph = false;
+bool verbose = false;
+bool debug = false;
 
 void usage(char *command)
 {
@@ -21,8 +25,11 @@ void usage(char *command)
   puts("\t--lat     <latitude>");
   puts("\t--lon     <longitude>");
   puts("\t--height  <height>");
-  puts("\t--epoch    <epoch>");
+  puts("\t--epoch   <epoch>");
   puts("\t--client  <X-SwiftNav-Client-Id header>");
+  puts("\t--no-eph  Disable ephemerides on connection (X-No-Ephemerides-On-Connection)");
+  puts("\t--verbose Enable curl verbose output");
+  puts("\t--debug   Enable debug output");
 }
 
 int parse_options(int argc, char *argv[])
@@ -34,6 +41,9 @@ int parse_options(int argc, char *argv[])
     OPT_HEIGHT,
     OPT_EPOCH,
     OPT_CLIENT,
+    OPT_NO_EPH,
+    OPT_VERBOSE,
+    OPT_DEBUG,
   };
 
   struct option long_opts[] = {
@@ -43,6 +53,9 @@ int parse_options(int argc, char *argv[])
     {"height",  required_argument, NULL, OPT_HEIGHT},
     {"epoch",   required_argument, NULL, OPT_EPOCH},
     {"client",  required_argument, NULL, OPT_CLIENT},
+    {"no-eph",  no_argument, NULL, OPT_NO_EPH},
+    {"verbose", no_argument, NULL, OPT_VERBOSE},
+    {"debug",   no_argument, NULL, OPT_DEBUG},
     {NULL,      0,                 NULL, 0},
   };
 
@@ -71,6 +84,18 @@ int parse_options(int argc, char *argv[])
       break;
       case OPT_CLIENT: {
         client = optarg;
+      }
+      break;
+      case OPT_NO_EPH: {
+        no_eph = true;
+      }
+      break;
+      case OPT_VERBOSE: {
+        verbose = true;
+      }
+      break;
+      case OPT_DEBUG: {
+        debug = true;
       }
       break;
       default: {
@@ -159,6 +184,26 @@ int progress(void *data, curl_off_t dltot, curl_off_t dlnow, curl_off_t ultot, c
   return 0;
 }
 
+static const char *curl_infotype_string[] = {
+  "CURLINFO_TEXT",         /* 0 */
+  "CURLINFO_HEADER_IN",    /* 1 */
+  "CURLINFO_HEADER_OUT",   /* 2 */
+  "CURLINFO_DATA_IN",      /* 3 */
+  "CURLINFO_DATA_OUT",     /* 4 */
+  "CURLINFO_SSL_DATA_IN",  /* 5 */
+  "CURLINFO_SSL_DATA_OUT", /* 6 */
+  "CURLINFO_END"
+};
+
+int debug_callback(CURL *handle,
+                   curl_infotype type,
+                   char *data,
+                   size_t size,
+                   void *clientp) {
+  printf("\n-----\nDEBUG - infotype = %s\n-----\n%s-----\n", curl_infotype_string[type], data);
+  return 0;
+}
+
 int request(void)
 {
   CURLcode code = curl_global_init(CURL_GLOBAL_ALL);
@@ -180,6 +225,9 @@ int request(void)
   chunk = curl_slist_append(chunk, "Transfer-Encoding:");
   chunk = curl_slist_append(chunk, "Ntrip-Version: Ntrip/2.0");
   chunk = curl_slist_append(chunk, client_header);
+  if (no_eph) {
+    chunk = curl_slist_append(chunk, "X-No-Ephemerides-On-Connection: True");
+  }
 
   char error_buf[CURL_ERROR_SIZE];
   curl_easy_setopt(curl, CURLOPT_HTTPHEADER,       chunk);
@@ -192,6 +240,14 @@ int request(void)
   curl_easy_setopt(curl, CURLOPT_NOPROGRESS,       0L);
   curl_easy_setopt(curl, CURLOPT_PUT,              1L);
   curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST,    "GET");
+
+  if (verbose || debug) {
+   curl_easy_setopt(curl, CURLOPT_VERBOSE,          1L);
+  }
+  if (debug) {
+   curl_easy_setopt(curl, CURLOPT_DEBUGFUNCTION,    debug_callback);
+  }
+
 #if LIBCURL_VERSION_MAJOR > 7 || (LIBCURL_VERSION_MAJOR >= 7 && LIBCURL_VERSION_MINOR >= 64)
   curl_easy_setopt(curl, CURLOPT_HTTP09_ALLOWED,   1L);
 #endif

--- a/src/ntrip_ping.c
+++ b/src/ntrip_ping.c
@@ -6,6 +6,7 @@
 #include <time.h>
 #include <curl/curl.h>
 #include <stdbool.h>
+#include <stdio.h>
 
 char *url = "conus.swiftnav.com:2101/VRS";
 char *lat = "37.77101999622968";
@@ -200,7 +201,7 @@ int debug_callback(CURL *handle,
                    char *data,
                    size_t size,
                    void *clientp) {
-  printf("\n-----\nDEBUG - infotype = %s\n-----\n%s-----\n", curl_infotype_string[type], data);
+  fprintf(stderr,"\n-----\nDEBUG - infotype = %s\n-----\n%s", curl_infotype_string[type], data);
   return 0;
 }
 


### PR DESCRIPTION
Add the following options:
- `--verbose` to enable the standard verbose output of curl
- `--debug` to enable the output from `CURLOPT_DEBUGFUNCTION`
- `--no-eph` to disable the burst of ephemeris messages upon connection by adding `X-No-Ephemerides-On-Connection` to the header